### PR TITLE
Removing the closing tag

### DIFF
--- a/postdir.php
+++ b/postdir.php
@@ -9,4 +9,4 @@
 
  date_default_timezone_set('America/Los_Angeles');
  file_put_contents ($dir.'/index.html', '<a href="http://google.com/maps?' . $_SERVER["QUERY_STRING"] . '">Click for last known location</a> (recorded at '. date('l jS \of F Y h:i:s A') . ' Pacific Time)');
-?>
+


### PR DESCRIPTION
Typically in a PHP application, the closing tag being placed in the file will allow output to occur after the closing file. Obviously, this file isn't 'outputting' to a page buffer, but it's still good to not have the closing tag (it's not required)
- http://stackoverflow.com/questions/4410704/why-would-one-omit-the-close-tag
